### PR TITLE
v0.2.0: Configure readiness and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ actual audito-maldito workload, and another one outputting the audit logs.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| health.enabled | bool | `true` |  |
+| health.readiness.initialDelaySeconds | int | `30` |  |
+| health.readiness.periodSeconds | int | `10` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/metal-toolbox/audito-maldito/audito-maldito"` |  |
-| image.tag | string | `"v0.1.7"` |  |
+| image.tag | string | `"v0.2.0"` |  |
+| metrics.enabled | bool | `true` |  |
 | priorityClassName | string | `""` |  |
 | resources.limits.cpu | int | `1` |  |
 | resources.limits.memory | string | `"512Mi"` |  |

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -44,7 +44,9 @@ spec:
           allowPrivilegeEscalation: false
         args:
           - "--healthz"
+        {{- if .Values.metrics.enabled }}
           - "--metrics"
+        {{- end }}
         env:
           - name: NODE_NAME
             valueFrom:
@@ -64,7 +66,12 @@ spec:
           mountPath: /var/run/audito-maldito
         - mountPath: /app-audit
           name: audit-logs
-        # TODO(jaosorior): Add readiness and liveness probes
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 2112
+          initialDelaySeconds: {{ .Values.health.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.health.readiness.periodSeconds }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       - name: audittail

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -42,6 +42,9 @@ spec:
         name: logfollower
         securityContext:
           allowPrivilegeEscalation: false
+        args:
+          - "--healthz"
+          - "--metrics"
         env:
           - name: NODE_NAME
             valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: ghcr.io/metal-toolbox/audito-maldito/audito-maldito
   pullPolicy: IfNotPresent
-  tag: "v0.1.7"
+  tag: "v0.2.0"
 resources:
   limits:
     cpu: 1

--- a/values.yaml
+++ b/values.yaml
@@ -13,3 +13,10 @@ resources:
     cpu: 1
     memory: 512Mi
 priorityClassName: ""
+metrics:
+  enabled: true
+health:
+  enabled: true
+  readiness:
+    initialDelaySeconds: 30
+    periodSeconds: 10


### PR DESCRIPTION
This upgrades to audito-maldito v0.2.0 to get the newest features. With this, it
adds readiness to the audito-maldito pod as well as enabling the metrics endpoint by default.

Note that this still needs an implementation of the ServiceMonitor to actually ingest metrics.
