### PR TITLE
Add node label to metrics

### DIFF
--- a/templates/pod-monitor.yml
+++ b/templates/pod-monitor.yml
@@ -13,6 +13,11 @@ spec:
       scheme: http
       scrapeTimeout: 5s
       port: http
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
This will include the node name as a label `node` per metric.