### PR TITLE
general: Cleanup container names and file path mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ actual audito-maldito workload, and another one outputting the audit logs.
 | health.readiness.periodSeconds | int | `10` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/metal-toolbox/audito-maldito/audito-maldito"` |  |
-| image.tag | string | `"v0.4.0"` |  |
+| image.tag | string | `"v0.4.1"` |  |
 | metrics.enabled | bool | `true` |  |
 | priorityClassName | string | `""` |  |
 | resources.limits.cpu | int | `1` |  |

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -36,7 +36,7 @@ spec:
         volumeMounts:
           - mountPath: /app-audit
             name: audit-logs
-      - name: init-audit-pipe
+      - name: init-linux-audit-logs-pipe
         image: ghcr.io/metal-toolbox/audittail:v0.5.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
@@ -73,7 +73,7 @@ spec:
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: Always
-        name: logfollower
+        name: audito-maldito
         securityContext:
           allowPrivilegeEscalation: false
         args:

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -92,17 +92,12 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
         volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-          readOnly: true
         - name: osrelease
           mountPath: /etc/os-release
           readOnly: true
         - name: machineid
           mountPath: /etc/machine-id
           readOnly: true
-        - name: runtime
-          mountPath: /var/run/audito-maldito
         - mountPath: /app-audit
           name: audit-logs
         readinessProbe:

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -158,9 +158,6 @@ spec:
         - name: machineid
           hostPath:
             path: /etc/machine-id
-        - name: runtime
-          hostPath:
-            path: /var/run/audito-maldito
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -75,6 +75,7 @@ spec:
         imagePullPolicy: Always
         name: audito-maldito
         securityContext:
+          runAsNonRoot: true
           allowPrivilegeEscalation: false
         args:
           - "--healthz"

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: ghcr.io/metal-toolbox/audito-maldito/audito-maldito
   pullPolicy: IfNotPresent
-  tag: "v0.4.0"
+  tag: "v0.4.8-dev"
 resources:
   limits:
     cpu: 1

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: ghcr.io/metal-toolbox/audito-maldito/audito-maldito
   pullPolicy: IfNotPresent
-  tag: "v0.4.8-dev"
+  tag: "v0.4.1"
 resources:
   limits:
     cpu: 1


### PR DESCRIPTION
These commits make the following changes:

- Clarify some of the container names
- Remove no-longer-needed file path mounts and volumes
- Add `runAsNonRoot` to the audito-maldito container (enforces running as UID != 0)