### PR TITLE
Sct 1272 memory requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ several containers:
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"250m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
+| rsyslog.resources.limits.cpu | string | `"500m"` |  |
+| rsyslog.resources.limits.memory | string | `"512Mi"` |  |
+| rsyslog.resources.requests.cpu | string | `"250m"` |  |
+| rsyslog.resources.requests.memory | string | `"256Mi"` |  |
 
 ## Development
 

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -142,12 +142,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         resources:
-          requests:
-            memory: "1Gi"
-            cpu: "250m"
-          limits:
-            memory: "2Gi"
-            cpu: "500m"
+{{ toYaml .Values.rsyslog.resources | indent 10 }}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,14 @@ resources:
   requests:
     cpu: 250m
     memory: 256Mi
+rsyslog:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 250m
+    limits:
+      memory: 512Mi
+      cpu: 500m
 priorityClassName: ""
 metrics:
   enabled: true


### PR DESCRIPTION
Extract rsyslog container resource requests and limits to values.
Give rsyslog lower default memory requests and limits based on production observations.
Update readme with new values.