### PR TITLE
Update audittail version

### DIFF
--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
       - name: init-audit-logs
-        image: ghcr.io/metal-toolbox/audittail:v0.5.0
+        image: ghcr.io/metal-toolbox/audittail:v0.9.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsNonRoot: true
@@ -37,7 +37,7 @@ spec:
           - mountPath: /app-audit
             name: audit-logs
       - name: init-linux-audit-logs-pipe
-        image: ghcr.io/metal-toolbox/audittail:v0.5.0
+        image: ghcr.io/metal-toolbox/audittail:v0.9.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsNonRoot: true
@@ -54,7 +54,7 @@ spec:
           - mountPath: /app-audit
             name: audit-logs
       - name: init-sshd-pipe
-        image: ghcr.io/metal-toolbox/audittail:v0.5.0
+        image: ghcr.io/metal-toolbox/audittail:v0.9.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsNonRoot: true
@@ -115,7 +115,7 @@ spec:
             name: http
             protocol: TCP
       - name: audittail
-        image: ghcr.io/metal-toolbox/audittail:v0.5.0
+        image: ghcr.io/metal-toolbox/audittail:v0.9.0
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
This updates audittail to the latest and fixes this vulnerability: https://equinixjira.atlassian.net/browse/SCT-1658.

Latest version of audittail: https://github.com/metal-toolbox/auditevent

Seems to run ok in this cluster: https://argo.stage.delivery.engineering/applications/argocd/audito-maldito-stage-dc13-sec?view=tree&resource=