### PR TITLE
Update audito-maldito image

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ several containers:
 | health.readiness.periodSeconds | int | `10` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/metal-toolbox/audito-maldito/audito-maldito"` |  |
-| image.tag | string | `"v0.5.1"` |  |
+| image.tag | string | `"v1.1.0"` |  |
 | metrics.enabled | bool | `true` |  |
 | priorityClassName | string | `""` |  |
 | resources.limits.cpu | string | `"200m"` |  |

--- a/templates/ds.yaml
+++ b/templates/ds.yaml
@@ -129,7 +129,7 @@ spec:
           - mountPath: /app-audit
             name: audit-logs
       - name: rsyslog
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}-rsyslog"
+        image: "{{ .Values.image.repository }}-rsyslog:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: Always
         command:
           - "rsyslogd"

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@
 image:
   repository: ghcr.io/metal-toolbox/audito-maldito/audito-maldito
   pullPolicy: IfNotPresent
-  tag: "v0.5.1"
+  tag: "v1.1.0"
 resources:
   limits:
     cpu: 200m


### PR DESCRIPTION
Update the audito-maldito image to v1.1.0 and update the matching rsyslog image to have `-rsyslog` in the name not the tag (as this is now how it's [named](https://github.com/metal-toolbox/audito-maldito/pull/151)).

Changes between [v0.5.1 -> v1.1.0](https://github.com/metal-toolbox/audito-maldito/compare/v0.5.1...v1.1.0):

- removes rocky and distro concept by [@​gradientsearch](https://redirect.github.com/gradientsearch) in [#​123](https://redirect.github.com/metal-toolbox/audito-maldito/pull/123)
- fix(deps): update module github.com/prometheus/client_golang to v1.17.0 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​121](https://redirect.github.com/metal-toolbox/audito-maldito/pull/121)
- chore(deps): update alpine docker tag to v3.18.4 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​122](https://redirect.github.com/metal-toolbox/audito-maldito/pull/122)
- fix(deps): update module golang.org/x/sync to v0.4.0 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​124](https://redirect.github.com/metal-toolbox/audito-maldito/pull/124)
- chore(deps): update docker/build-push-action digest to [fdf7f43](https://redirect.github.com/metal-toolbox/audito-maldito/commit/fdf7f43) by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​125](https://redirect.github.com/metal-toolbox/audito-maldito/pull/125)
- removes-unused-package-nxadm-tail by [@​gradientsearch](https://redirect.github.com/gradientsearch) in [#​127](https://redirect.github.com/metal-toolbox/audito-maldito/pull/127)
- chore(deps): update codacy/codacy-analysis-cli-action digest to [240c610](https://redirect.github.com/metal-toolbox/audito-maldito/commit/240c610) by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​130](https://redirect.github.com/metal-toolbox/audito-maldito/pull/130)
- fix(deps): update module github.com/fsnotify/fsnotify to v1.7.0 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​129](https://redirect.github.com/metal-toolbox/audito-maldito/pull/129)
- chore(deps): update golangci/golangci-lint docker tag to v1.55.1 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​128](https://redirect.github.com/metal-toolbox/audito-maldito/pull/128)
- chore(deps): update docker/login-action digest to [1f401f7](https://redirect.github.com/metal-toolbox/audito-maldito/commit/1f401f7) by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​132](https://redirect.github.com/metal-toolbox/audito-maldito/pull/132)
- chore(deps): update docker/metadata-action digest to [62339db](https://redirect.github.com/metal-toolbox/audito-maldito/commit/62339db) by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​133](https://redirect.github.com/metal-toolbox/audito-maldito/pull/133)
- ci: Use cosign to sign audito-maldito image. by [@​stephen-fox](https://redirect.github.com/stephen-fox) in [#​142](https://redirect.github.com/metal-toolbox/audito-maldito/pull/142)
- chore(deps): update github/codeql-action action to v3 by [@​renovate](https://redirect.github.com/renovate)[bot] in [#​144](https://redirect.github.com/metal-toolbox/audito-maldito/pull/144)
- turn off debug mode by [@​gradientsearch](https://redirect.github.com/gradientsearch) in [#​148](https://redirect.github.com/metal-toolbox/audito-maldito/pull/148)
- Fix CI errors by [@​oliver-equinix](https://redirect.github.com/oliver-equinix) in [#​153](https://redirect.github.com/metal-toolbox/audito-maldito/pull/153)
- Fix image signing on rsyslog image by [@​oliver-equinix](https://redirect.github.com/oliver-equinix) in [#​151](https://redirect.github.com/metal-toolbox/audito-maldito/pull/151)
- chore(deps): update docker/login-action digest to [343f7c4](https://redirect.github.com/metal-toolbox/audito-maldito/commit/343f7c4) by [@​renovate](https://redirect.github.com/renovate) in [#​101](https://redirect.github.com/metal-toolbox/audito-maldito/pull/101)
- chore(deps): update docker/metadata-action digest to [1f35ebc](https://redirect.github.com/metal-toolbox/audito-maldito/commit/1f35ebc) by [@​renovate](https://redirect.github.com/renovate) in [#​102](https://redirect.github.com/metal-toolbox/audito-maldito/pull/102)
- chore(deps): update docker/build-push-action digest to [4c1b68d](https://redirect.github.com/metal-toolbox/audito-maldito/commit/4c1b68d) by [@​renovate](https://redirect.github.com/renovate) in [#​100](https://redirect.github.com/metal-toolbox/audito-maldito/pull/100)
- fix(deps): update module go.uber.org/zap to v1.26.0 by [@​renovate](https://redirect.github.com/renovate) in [#​107](https://redirect.github.com/metal-toolbox/audito-maldito/pull/107)
- chore(deps): update alpine docker tag to v3.18.3 by [@​renovate](https://redirect.github.com/renovate) in [#​108](https://redirect.github.com/metal-toolbox/audito-maldito/pull/108)
- chore(deps): update golang docker tag to v1.21 by [@​renovate](https://redirect.github.com/renovate) in [#​109](https://redirect.github.com/metal-toolbox/audito-maldito/pull/109)
- chore(deps): update golangci/golangci-lint docker tag to v1.54.2 by [@​renovate](https://redirect.github.com/renovate) in [#​110](https://redirect.github.com/metal-toolbox/audito-maldito/pull/110)
- fix(deps): update module github.com/elastic/go-libaudit/v2 to v2.3.3 by [@​renovate](https://redirect.github.com/renovate) in [#​112](https://redirect.github.com/metal-toolbox/audito-maldito/pull/112)
- chore(deps): update actions/checkout action to v4 by [@​renovate](https://redirect.github.com/renovate) in [#​116](https://redirect.github.com/metal-toolbox/audito-maldito/pull/116)
- chore(deps): update codacy/codacy-analysis-cli-action digest to [3b66437](https://redirect.github.com/metal-toolbox/audito-maldito/commit/3b66437) by [@​renovate](https://redirect.github.com/renovate) in [#​117](https://redirect.github.com/metal-toolbox/audito-maldito/pull/117)
- chore(deps): update docker/login-action digest to [b4bedf8](https://redirect.github.com/metal-toolbox/audito-maldito/commit/b4bedf8) by [@​renovate](https://redirect.github.com/renovate) in [#​118](https://redirect.github.com/metal-toolbox/audito-maldito/pull/118)
- chore(deps): update docker/build-push-action action to v5 by [@​renovate](https://redirect.github.com/renovate) in [#​119](https://redirect.github.com/metal-toolbox/audito-maldito/pull/119)
- chore(deps): update docker/metadata-action digest to [879dcbb](https://redirect.github.com/metal-toolbox/audito-maldito/commit/879dcbb) by [@​renovate](https://redirect.github.com/renovate) in [#​120](https://redirect.github.com/metal-toolbox/audito-maldito/pull/120)

BEGIN_COMMIT_OVERRIDE
fix: update audito-maldito image
END_COMMIT_OVERRIDE